### PR TITLE
Убрал строгое определение высоты в .step-info

### DIFF
--- a/CSS/index.css
+++ b/CSS/index.css
@@ -55,7 +55,6 @@ header a{
 }
 .step-info{
 	width: 450px;
-	height: 120px;
 	font-size: 20px;
 	display: grid;
 	align-items: center;


### PR DESCRIPTION
Убрал строгое определение высоты в step-info. Строка "Вы: 0" не влезала в белую рамку из-за фиксированной высоты.